### PR TITLE
fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/karldoenitz/grpcall
+module github.com/rfyiamcool/grpcall
 
 require (
 	github.com/fullstorydev/grpcurl v1.1.0


### PR DESCRIPTION
go: github.com/rfyiamcool/grpcall@v0.0.0-20200323110021-3ac3911f2256: parsing go.mod:
	module declares its path as: github.com/karldoenitz/grpcall
	        but was required as: github.com/rfyiamcool/grpcall